### PR TITLE
fix multiple file processing

### DIFF
--- a/tasks/vulcanize.js
+++ b/tasks/vulcanize.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
     });
 
     // Iterate over all specified file groups.
+    var count = this.files.length;
     this.files.forEach(function(f) {
       // Concat specified files.
       var src = f.src.filter(function(filepath) {
@@ -53,7 +54,10 @@ module.exports = function(grunt) {
         vulcanize.processDocument();
         grunt.log.ok();
         grunt.verbose.writeln('wrote %s', f.dest + (!options.csp ? '' : ' and ' + f.dest.replace('.html', '.js')));
-        done();
+        count--;
+        if (count === 0) {
+          done();
+        }
       });
 
     });


### PR DESCRIPTION
When processing more than one file at a time, the done() callback is
called as many times as there are files. This mess up the Grunt state
machine, triggering launching of other tasks before the result of the
previous ones is actually completed.
