### PR TITLE
Update to latest vulcanize

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "vulcanize": "^0.4.1"
+    "vulcanize": "^0.4.2"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Outdated Dependencies prior to this change:

vulcanize (package: ^0.4.1, latest: 0.4.2)
